### PR TITLE
Fix pre-commit Terraform hooks in MacOS (arm64)

### DIFF
--- a/roles/macbook/defaults/main.yml
+++ b/roles/macbook/defaults/main.yml
@@ -17,6 +17,7 @@ base_package_list:
   - tmux # Virtual terminal tool
   - vault # Hashicorp's secret manager
   - yq # Yaml parser
+  - bash # Update bash from 3.2 to 5.x to fix this https://github.com/antonbabenko/pre-commit-terraform/issues/337
 
 # Optional packages for k8s and terraform
 k8s_package_list:


### PR DESCRIPTION
This PR offers a workaround to this issue https://github.com/antonbabenko/pre-commit-terraform/issues/337. It just updates the bash version from 3.2 to 5.x