### PR TITLE
add secretive to base packages list

### DIFF
--- a/roles/macbook/defaults/main.yml
+++ b/roles/macbook/defaults/main.yml
@@ -18,6 +18,7 @@ base_package_list:
   - vault # Hashicorp's secret manager
   - yq # Yaml parser
   - bash # Update bash from 3.2 to 5.x to fix this https://github.com/antonbabenko/pre-commit-terraform/issues/337
+  - secretive # enable saving ssh keys in the Secure Enclave https://support.apple.com/guide/security/secure-enclave-sec59b0b31ff/web 
 
 # Optional packages for k8s and terraform
 k8s_package_list:


### PR DESCRIPTION
I would love to add the following as well, but I don't know ansible well enough.

`~/.ssh/config`
```
Host *
  ServerAliveInterval 60
  IdentityAgent ~/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh
```

create symlink
`~/.ssh/secretive-public-keys -> ~/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/PublicKeys`