### PR TITLE
[CORE-1772] Updated helm diff version to support arm64 arch

### DIFF
--- a/roles/macbook/tasks/k8s.yml
+++ b/roles/macbook/tasks/k8s.yml
@@ -39,7 +39,7 @@
     - {
         name: helm-diff,
         url: https://github.com/databus23/helm-diff,
-        version: v3.1.3,
+        version: v3.6.0,
       }
     - {
         name: helm-git,


### PR DESCRIPTION
While installing helm-diff tool, I ran into the below error. Doing a 3.1.3 -> 3.3.0 upgrade fixes this. 

```
failed: [localhost] (item={'name': 'helm-diff', 'url': 'https://github.com/databus23/helm-diff', 'version': 'v3.1.3'}) => changed=true 
  ansible_loop_var: item
  cmd:
  - helm
  - plugin
  - install
  - https://github.com/databus23/helm-diff
  - --version
  - v3.1.3
  delta: '0:00:04.612550'
  end: '2023-02-23 11:57:32.160696'
  item:
    name: helm-diff
    url: https://github.com/databus23/helm-diff
    version: v3.1.3
  msg: non-zero return code
  rc: 1
  start: '2023-02-23 11:57:27.548146'
  stderr: 'Error: plugin install hook for "diff" exited with error'
  stderr_lines: <omitted>
  stdout: |-
    No prebuild binary for macos-arm64.
    Failed to install helm-diff
            For support, go to https://github.com/databus23/helm-diff.
  stdout_lines: <omitted>
```

After upgrade:

![image](https://user-images.githubusercontent.com/24836159/220988072-f80c6505-13ed-40c3-be59-62299ed00491.png)
