### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @anaconda/anaconda-devops will be requested for
+# review when someone opens a pull request.
+*       @anaconda/anaconda-devops @anaconda/anaconda-devops-onduty


### PR DESCRIPTION
This adds a `CODEOWNERS` file so that the Anaconda DevOps team gets notified about new PRs by renovate.
