### PR TITLE
Add argocd CLI to k8s_package_list

### DIFF
--- a/roles/macbook/defaults/main.yml
+++ b/roles/macbook/defaults/main.yml
@@ -32,6 +32,7 @@ k8s_package_list:
   - krew
   - kubectl
   - kustomize
+  - argocd
 
 tf_package_list:
   - tflint


### PR DESCRIPTION
The argocd CLI is needed for https://github.com/anaconda/infra/blob/main/docs/bootstrapping-eks-cluster.md